### PR TITLE
Allow customize the universal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Change `WECHAT_APP_ID` with your Wechat App ID. Check demo project `demo/App_Res
 
 For details you can check the demo project.
 
-In your `main.ts` or `app.ts` need to import `initWechatSdk(WECHAT_APP_ID)` method with wechat app id.
+In your `main.ts` or `app.ts` need to import `initWechatSdk(WECHAT_APP_ID, UNIVERSAL_LINK)` method with wechat app id.
 
 ```javascript
 ....
 import { initWechatSdk } from "nativescript-wechat-login";
 
-initWechatSdk("wxd930ea5d5a258f4f");
+initWechatSdk("wxd930ea5d5a258f4f", "https://www.your.app.universal.link");
 ```
 
 In any other page

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -4,6 +4,6 @@ import { initWechatSdk } from "nativescript-wechat-login";
 
 import { AppModule } from "./app/app.module";
 
-initWechatSdk("wxd930ea5d5a258f4f");
+initWechatSdk("wxd930ea5d5a258f4f", "https://www.your.app.universal.link");
 
 platformNativeScriptDynamic().bootstrapModule(AppModule);

--- a/src/getappdelegate.ios.ts
+++ b/src/getappdelegate.ios.ts
@@ -40,7 +40,6 @@ export function setupAppDeligate(wechatAppId, universalLink) {
     enableMultipleOverridesFor(appDelegate, 'applicationHandleOpenURL', function (application, url) {
         return WXApi.handleOpenURLDelegate(url, WXApiManagerDelegate.new())
     });
-
     enableMultipleOverridesFor(appDelegate, 'applicationOpenURLSourceApplicationAnnotation', function (application, url, sourceApplication, annotation) {
         try {
             return WXApi.handleOpenURLDelegate(url, WXApiManagerDelegate.new())
@@ -49,6 +48,9 @@ export function setupAppDeligate(wechatAppId, universalLink) {
             console.log(e);
         }
 
+    });
+    enableMultipleOverridesFor(appDelegate, 'applicationContinueUserActivityRestorationHandler', function (application, userActivity, handler) {
+        return WXApi.handleOpenUniversalLinkDelegate(userActivity, WXApiManagerDelegate.new());
     });
 }
 
@@ -61,14 +63,14 @@ class WXApiManagerDelegate extends NSObject {
     }
 
     public onReq(res) {
-        //console.log("onReq")
+        console.log("onReq")
     }
 
     /**
      * onResp
      */
     public onResp(res) {
-        //console.log("BaseResp")
+        console.log("BaseResp")
         setTimeout(() => {
             application.notify(<ApplicationEventData>{
                 eventName: 'wxApiResponse',

--- a/src/getappdelegate.ios.ts
+++ b/src/getappdelegate.ios.ts
@@ -28,12 +28,12 @@ export function enableMultipleOverridesFor(classRef, methodName, nextImplementat
     };
 }
 
-export function setupAppDeligate(wechatAppId) {
+export function setupAppDeligate(wechatAppId, universalLink) {
 
     let appDelegate = getAppDelegate();
 
     enableMultipleOverridesFor(appDelegate, 'applicationDidFinishLaunchingWithOptions', function (application, launchOptions) {
-        WXApi.registerAppUniversalLink(wechatAppId, "https://help.wechat.com/sdksample/");
+        WXApi.registerAppUniversalLink(wechatAppId, universalLink);
         return true;
     });
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nativescript-wechat-login",
     "version": "1.0.6",
-    "description": "Wechat Login plugin for nativescript.",
+    "description": "Wechat Login plugin for nativescript. it is forked from https://github.com/jibon57/nativescript-wechat-login.git with fix for universal link",
     "main": "wechat-login",
     "typings": "index.d.ts",
     "nativescript": {
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/jibon57/nativescript-wechat-login.git"
+        "url": "https://github.com/luffyzc/nativescript-wechat-login-1.git"
     },
     "scripts": {
         "tsc": "npm i && tsc",
@@ -40,14 +40,14 @@
         "wechat login nativescript"
     ],
     "author": {
-        "name": "Jibon L. Costa",
-        "email": "jiboncosta57@gmail.com"
+        "name": "Chi Zhang",
+        "email": "luffyzc1994@gmail.com"
     },
     "bugs": {
-        "url": "https://github.com/jibon57/nativescript-wechat-login/issues"
+        "url": "https://github.com/luffyzc/nativescript-wechat-login-1/issues"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/jibon57/nativescript-wechat-login",
+    "homepage": "https://github.com/luffyzc/nativescript-wechat-login-1",
     "readmeFilename": "README.md",
     "devDependencies": {
         "tns-core-modules": "^6.0.0",


### PR DESCRIPTION
## What is the current behavior?
initWechatSdk current register the wechatAppId to a default univerisalLink "https://help.wechat.com/sdksample/"

## What is the new behavior?
Modify the method initWechatSdk to accepct additional param `univerisalLink` to allow customers to specify their universalLink
